### PR TITLE
🐛  Bug : LoginResponse의 refreshToken이 null로 반환되는 문제 해결

### DIFF
--- a/src/main/java/backend/like_house/domain/auth/converter/AuthConverter.java
+++ b/src/main/java/backend/like_house/domain/auth/converter/AuthConverter.java
@@ -12,9 +12,10 @@ public class AuthConverter {
                 .build();
     }
 
-    public static AuthDTO.SignInResponse toSignInResponseDTO(String accessToken) {
+    public static AuthDTO.SignInResponse toSignInResponseDTO(String accessToken, String refreshToken) {
         return AuthDTO.SignInResponse.builder()
                 .accessToken(accessToken)
+                .refreshToken(refreshToken)
                 .build();
     }
 

--- a/src/main/java/backend/like_house/domain/auth/service/impl/AuthCommandServiceImpl.java
+++ b/src/main/java/backend/like_house/domain/auth/service/impl/AuthCommandServiceImpl.java
@@ -59,6 +59,6 @@ public class AuthCommandServiceImpl implements AuthCommandService {
         // Redis에 RefreshToken 저장
         redisUtil.saveRefreshToken(user.getEmail(), refreshToken);
 
-        return AuthConverter.toSignInResponseDTO(accessToken);
+        return AuthConverter.toSignInResponseDTO(accessToken, refreshToken);
     }
 }


### PR DESCRIPTION
# 💡 PR Summary - LoginResponse의 refreshToken이 null로 반환되는 문제 해결
<!-- 어떤 작업에 대한 PR 인지 위 주석에 적어주세요 -->

### 📝 Description

---
<!-- 어떤 작업을 했는지 간단하게 적어주세요 -->
Converter에서 loginResponse DTO를 생성하는 과정에서 refreshToken을 빠뜨려서 null로 반환되는 문제가 있었습니다.
이 문제 해결하기 위해 Converter의 코드를 수정하고, service단에서 리턴하는 값에도 refreshToken을 추가하였습니다.

### 🌲 Working Branch

---
<!-- 예시) feature/user -->
bug/#29

### 📖 Related Issues

---
<!-- 예시) #1 -->
#29 


### 📚 Etc

---
<!-- 작업 중 특이사항이 생기면 적어주세요 -->
특이사항
