### PR TITLE
🐛  Bug : header에 accessToken이 담기지 않는 문제

### DIFF
--- a/src/main/java/backend/like_house/global/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/backend/like_house/global/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -31,8 +31,6 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
             // 최초 OAuth 로그인 시 Guest
             if (oAuth2User.getRole() == Role.ROLE_GUEST) {
                 String accessToken = jwtUtil.generateAccessToken(oAuth2User.getEmail(), oAuth2User.getSocialType());
-                response.addHeader(jwtUtil.getAccessHeader(), "Bearer " + accessToken);
-
                 jwtUtil.sendAccessAndRefreshToken(response, accessToken, null);
             } else {
                 loginSuccess(response, oAuth2User);
@@ -46,10 +44,8 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         String accessToken = jwtUtil.generateAccessToken(oAuth2User.getEmail(), oAuth2User.getSocialType());
         String refreshToken = jwtUtil.generateRefreshToken(oAuth2User.getEmail(), oAuth2User.getSocialType());
 
-        response.addHeader(jwtUtil.getAccessHeader(), "Bearer " + accessToken);
-        response.addHeader(jwtUtil.getRefreshHeader(), "Bearer " + refreshToken);
-
         jwtUtil.sendAccessAndRefreshToken(response, accessToken, refreshToken);
+
         redisUtil.saveRefreshToken(oAuth2User.getEmail(), oAuth2User.getSocialType(), refreshToken);
     }
 }

--- a/src/main/java/backend/like_house/global/security/SecurityConfig.java
+++ b/src/main/java/backend/like_house/global/security/SecurityConfig.java
@@ -92,7 +92,7 @@ public class SecurityConfig implements WebMvcConfigurer {
                         "http://localhost:5173")
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH")
                 .allowedHeaders("*")
-                .exposedHeaders("Authorization")
+                .exposedHeaders("Authorization", "Authorization-refresh")
                 .allowCredentials(true)
                 .maxAge(3600);
     }


### PR DESCRIPTION
# 💡 PR Summary - header에 accessToken이 담기지 않는 문제
<!-- 어떤 작업에 대한 PR 인지 위 주석에 적어주세요 -->

### 📝 Description

---
<!-- 어떤 작업을 했는지 간단하게 적어주세요 -->
두 번 들어가 있는 header 설정 로직을 하나로 통합했습니다.

### 🌲 Working Branch

---
<!-- 예시) feature/user -->
bug/#83

### 📖 Related Issues

---
<!-- 예시) #1 -->
#83 


### 📚 Etc

---
<!-- 작업 중 특이사항이 생기면 적어주세요 -->
백엔드 로컬에서는 잘 동작하는거 확인했습니다.
프론트에서 소셜로그인 이후 redirect-uri로의 응답이 200으로 오지만, response header에 authorization이 설정되지 않습니다..
header를 설정하는 것이 중첩되어 발생하는 문제인가 싶어 해당 부분 수정했습니다. 
