### PR TITLE
♻️ Refactor : 가족 앨범 조회 시 대표 이미지 하나만 반환

### DIFF
--- a/src/main/java/backend/like_house/domain/post/repository/PostImageRepository.java
+++ b/src/main/java/backend/like_house/domain/post/repository/PostImageRepository.java
@@ -4,6 +4,7 @@ import backend.like_house.domain.post.entity.Post;
 import backend.like_house.domain.post.entity.PostImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,7 +14,6 @@ public interface PostImageRepository extends JpaRepository<PostImage, Long> {
     List<PostImage> findByPostId(Long postId);
 
     // 특정 게시글의 첫 번째 이미지를 가져오는 메소드
-    @Query("SELECT pi FROM PostImage pi WHERE pi.post.id = :postId")
-    Optional<PostImage> findFirstByPostId(Long postId);
+    @Query("SELECT pi FROM PostImage pi WHERE pi.post.id = :postId ORDER BY pi.id ASC")
+    List<PostImage> findFirstByPostId(@Param("postId") Long postId);
 }
-

--- a/src/main/java/backend/like_house/domain/post/service/impl/FamilyAlbumQueryServiceImpl.java
+++ b/src/main/java/backend/like_house/domain/post/service/impl/FamilyAlbumQueryServiceImpl.java
@@ -51,7 +51,8 @@ public class FamilyAlbumQueryServiceImpl implements FamilyAlbumQueryService {
         // 각 게시글의 대표 이미지를 AlbumPhotoResponse로 변환하여 반환
         return posts.stream()
                 .map(post -> {
-                    PostImage representativeImage = postImageRepository.findFirstByPostId(post.getId()).orElse(null);
+                    List<PostImage> postImages = postImageRepository.findFirstByPostId(post.getId());
+                    PostImage representativeImage = postImages.isEmpty() ? null : postImages.get(0);
                     String representativeImageUrl = (representativeImage != null) ? representativeImage.getFilename() : null;
                     return FamilyAlbumConverter.toAlbumPhotoResponse(post, representativeImageUrl);
                 })


### PR DESCRIPTION
# 💡 PR Summary - 가족 앨범 조회 시 대표 이미지 하나만 반환 <!--{ 작업 내용 }-->
<!-- 어떤 작업에 대한 PR 인지 위 주석에 적어주세요 -->

### 📝 Description

---
<!-- 어떤 작업을 했는지 간단하게 적어주세요 -->
가족 앨범 조회 시 대표 이미지 하나만 반환하도록 수정

### 🌲 Working Branch

---
<!-- 예시) feature/user -->
refactor/#85

### 📖 Related Issues

---
<!-- 예시) #1 -->
#85 


### 📚 Etc

---
<!-- 작업 중 특이사항이 생기면 적어주세요 -->
특이사항
