### PR TITLE
:recycle: Refactor : 소켓 500에러 디스 코드 보내기 기능 추가

### DIFF
--- a/src/main/java/backend/like_house/global/socket/WebSocketConfig.java
+++ b/src/main/java/backend/like_house/global/socket/WebSocketConfig.java
@@ -1,5 +1,6 @@
 package backend.like_house.global.socket;
 
+import backend.like_house.global.error.exception.alarmClient.service.DiscordClient;
 import backend.like_house.global.security.util.JWTUtil;
 import backend.like_house.global.socket.handler.CustomWebSocketExceptionHandler;
 import backend.like_house.global.socket.handler.JWTInterceptor;
@@ -8,6 +9,7 @@ import backend.like_house.global.socket.handler.TextHandler;
 import backend.like_house.global.socket.service.SocketService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
@@ -20,10 +22,12 @@ public class WebSocketConfig implements WebSocketConfigurer {
     private final SocketService socketService;
     private final SocketUtil socketUtil;
     private final JWTUtil jwtUtil;
+    private final DiscordClient discordClient;
+    private final Environment environment;
 
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-        registry.addHandler(new CustomWebSocketExceptionHandler(new TextHandler(socketService, socketUtil)), "/chat")
+        registry.addHandler(new CustomWebSocketExceptionHandler(new TextHandler(socketService, socketUtil), discordClient, environment), "/chat")
                 .addInterceptors(new JWTInterceptor(jwtUtil, socketUtil))
                 .setAllowedOrigins("*")
                 .withSockJS();

--- a/src/main/java/backend/like_house/global/socket/handler/CustomWebSocketExceptionHandler.java
+++ b/src/main/java/backend/like_house/global/socket/handler/CustomWebSocketExceptionHandler.java
@@ -1,8 +1,11 @@
 package backend.like_house.global.socket.handler;
 
+import backend.like_house.global.error.exception.alarmClient.dto.DiscordMessage;
+import backend.like_house.global.error.exception.alarmClient.service.DiscordClient;
 import backend.like_house.global.error.handler.ChatException;
 import backend.like_house.global.error.handler.ChatRoomException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.env.Environment;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketHandler;
@@ -10,11 +13,22 @@ import org.springframework.web.socket.WebSocketMessage;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.ExceptionWebSocketHandlerDecorator;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
 @Slf4j
 public class CustomWebSocketExceptionHandler extends ExceptionWebSocketHandlerDecorator {
 
-    public CustomWebSocketExceptionHandler(WebSocketHandler delegate) {
+    private final DiscordClient discordClient;
+    private final Environment environment;
+
+    public CustomWebSocketExceptionHandler(WebSocketHandler delegate, DiscordClient discordClient, Environment environment) {
         super(delegate);
+        this.discordClient = discordClient;
+        this.environment = environment;
     }
 
     @Override
@@ -35,6 +49,9 @@ public class CustomWebSocketExceptionHandler extends ExceptionWebSocketHandlerDe
                 e.printStackTrace();
                 String errorMessage = "{\"isSuccess\": \"false\", \"code\": \"500\", \"message\": \"예외적 오류 서버 로그를 확인 해보 세요.\"}";
                 session.sendMessage(new TextMessage(errorMessage));
+                if (!Arrays.asList(environment.getActiveProfiles()).contains("local")) {
+                    discordClient.sendAlarm(createMessage(e));
+                }
             }
         } catch (Exception e) {
             e.printStackTrace();
@@ -52,5 +69,33 @@ public class CustomWebSocketExceptionHandler extends ExceptionWebSocketHandlerDe
         SocketUtil socketUtil = new SocketUtil();
         socketUtil.exitAllSessionChatRoom(session);
         super.afterConnectionClosed(session, closeStatus);
+    }
+
+    private DiscordMessage createMessage(Exception e) {
+        return DiscordMessage.builder()
+                .content("# 🚨 에러 발생 비이이이이사아아아앙")
+                .embeds(
+                        List.of(
+                                DiscordMessage.Embed.builder()
+                                        .title("ℹ️ 에러 정보")
+                                        .description(
+                                                "### 🕖 발생 시간\n"
+                                                        + LocalDateTime.now()
+                                                        + "\n"
+                                                        + "### 🔗 요청 URL\n"
+                                                        + "소켓 관련 에러"
+                                                        + "\n"
+                                                        + "### 📄 Stack Trace\n"
+                                                        + "```\n"
+                                                        + getStackTrace(e).substring(0, 1000)
+                                                        + "\n```")
+                                        .build()))
+                .build();
+    }
+
+    private String getStackTrace(Exception e) {
+        StringWriter stringWriter = new StringWriter();
+        e.printStackTrace(new PrintWriter(stringWriter));
+        return stringWriter.toString();
     }
 }


### PR DESCRIPTION
# 💡 PR Summary - 소켓 500에러 디스 코드 보내기 기능 추가<!--{ 작업 내용 }-->
<!-- 어떤 작업에 대한 PR 인지 위 주석에 적어주세요 -->

### 📝 Description

---
<!-- 어떤 작업을 했는지 간단하게 적어주세요 -->
소켓의 경우 controller를 지나가지 않기 때문에 RestControllerAdvice를 거치지 않게 되고 discord로 알림이 안감. 그렇기에 소켓 에러 핸들러에 따로 설정하였습니다.

### 🌲 Working Branch

---
<!-- 예시) feature/user -->
feature/#122

### 📖 Related Issues

---
<!-- 예시) #1 -->
#122 


### 📚 Etc

---
<!-- 작업 중 특이사항이 생기면 적어주세요 -->
특이사항
