### PR TITLE
♻️ Refactor : 소셜로그인 이후 JWT를 쿠키로 반환하도록 수정

### DIFF
--- a/src/main/java/backend/like_house/domain/auth/controller/AuthController.java
+++ b/src/main/java/backend/like_house/domain/auth/controller/AuthController.java
@@ -7,6 +7,8 @@ import backend.like_house.global.common.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
@@ -50,8 +52,8 @@ public class AuthController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH4001", description = "유효하지 않은 토큰입니다.")
 
     })
-    public ApiResponse<String> signOut(@RequestBody @Valid AuthDTO.TokenRequest tokenRequest) {
-        authCommandService.signOut(tokenRequest);
+    public ApiResponse<String> signOut(HttpServletRequest request, HttpServletResponse response) {
+        authCommandService.signOut(request, response);
         return ApiResponse.onSuccess("로그아웃 성공");
     }
 
@@ -61,8 +63,8 @@ public class AuthController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH4001", description = "유효하지 않은 토큰입니다.")
     })
-    public ApiResponse<String> deleteAccount(@RequestBody @Valid AuthDTO.TokenRequest deleteAccountRequest) {
-        authCommandService.deleteUser(deleteAccountRequest);
+    public ApiResponse<String> deleteAccount(HttpServletRequest request, HttpServletResponse response) {
+        authCommandService.deleteUser(request, response);
         return ApiResponse.onSuccess("회원 탈퇴 성공");
     }
 

--- a/src/main/java/backend/like_house/domain/auth/service/AuthCommandService.java
+++ b/src/main/java/backend/like_house/domain/auth/service/AuthCommandService.java
@@ -2,6 +2,8 @@ package backend.like_house.domain.auth.service;
 
 import backend.like_house.domain.auth.dto.AuthDTO;
 import backend.like_house.domain.auth.dto.EmailDTO;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 public interface AuthCommandService {
 
@@ -9,9 +11,9 @@ public interface AuthCommandService {
 
     AuthDTO.SignInResponse signIn(AuthDTO.SignInRequest request);
 
-    void signOut(AuthDTO.TokenRequest request);
+    void signOut(HttpServletRequest request, HttpServletResponse response);
 
-    void deleteUser(AuthDTO.TokenRequest request);
+    void deleteUser(HttpServletRequest request, HttpServletResponse response);
 
     EmailDTO.EmailSendResponse sendCode(String email);
 

--- a/src/main/java/backend/like_house/domain/auth/service/impl/AuthCommandServiceImpl.java
+++ b/src/main/java/backend/like_house/domain/auth/service/impl/AuthCommandServiceImpl.java
@@ -149,6 +149,12 @@ public class AuthCommandServiceImpl implements AuthCommandService {
         cookie.setHttpOnly(true);
         cookie.setMaxAge(0);
         response.addCookie(cookie);
+
+        Cookie refreshTokenCookie = new Cookie("refreshToken", null);
+        refreshTokenCookie.setPath("/");
+        refreshTokenCookie.setHttpOnly(true);
+        refreshTokenCookie.setMaxAge(0);
+        response.addCookie(refreshTokenCookie);
     }
 
     private String resolveToken(HttpServletRequest request) {

--- a/src/main/java/backend/like_house/global/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/backend/like_house/global/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -1,6 +1,5 @@
 package backend.like_house.global.oauth2.handler;
 
-import backend.like_house.domain.user.entity.Role;
 import backend.like_house.global.oauth2.CustomOAuth2User;
 import backend.like_house.global.redis.RedisUtil;
 import backend.like_house.global.security.util.JWTUtil;
@@ -47,6 +46,12 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         jwtCookie.setHttpOnly(true);
         jwtCookie.setMaxAge(3600);
         response.addCookie(jwtCookie);
+
+        Cookie refreshCookie = new Cookie("refreshToken", refreshToken);
+        refreshCookie.setPath("/");
+        refreshCookie.setHttpOnly(true);
+        refreshCookie.setMaxAge(604800);
+        response.addCookie(refreshCookie);
 
         response.sendRedirect("http://localhost:5173");
     }

--- a/src/main/java/backend/like_house/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/backend/like_house/global/security/filter/JwtAuthenticationFilter.java
@@ -4,7 +4,6 @@ import backend.like_house.domain.user.entity.SocialType;
 import backend.like_house.global.error.code.status.ErrorStatus;
 import backend.like_house.global.error.handler.AuthException;
 import backend.like_house.global.security.util.JWTUtil;
-import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;


### PR DESCRIPTION
# 💡 PR Summary - 소셜로그인 이후 JWT를 쿠키로 반환하도록 수정
<!-- 어떤 작업에 대한 PR 인지 위 주석에 적어주세요 -->

### 📝 Description

---
<!-- 어떤 작업을 했는지 간단하게 적어주세요 -->
소셜로그인 이후 JWT를 쿠키로 반환하도록 수정하였습니다.
기존 일반 로그인의 경우는 쿠키를 사용하지 않고 있기 때문에 인가 과정을 경우에 따라 로직을 수정하였습니다.
쿠키를 사용하는 경우 클라이언트 측에서 토큰을 직접 다룰 필요 없이 서버 단에서 토큰 재발급이 이루어집니다.

### 🌲 Working Branch

---
<!-- 예시) feature/user -->
refactor/#149

### 📖 Related Issues

---
<!-- 예시) #1 -->
#149 


### 📚 Etc

---
<!-- 작업 중 특이사항이 생기면 적어주세요 -->
특이사항
